### PR TITLE
UIViewController + BackButtonItemTitle

### DIFF
--- a/Categories/UIKit/UIViewController/UIViewController+BackButtonItemTitle.h
+++ b/Categories/UIKit/UIViewController/UIViewController+BackButtonItemTitle.h
@@ -1,0 +1,20 @@
+//
+//  UIViewController+BackButtonItemTitle.h
+//  Author ： https://github.com/KevinHM
+//
+//  Created by KevinHM on 15/8/6.
+//  Copyright (c) 2015年 KevinHM. All rights reserved.
+//
+
+#import <UIKit/UIKit.h>
+
+@protocol BackButtonItemTitleProtocol <NSObject>
+
+@optional
+- (NSString *)navigationItemBackBarButtonTitle; //The length of the text is limited, otherwise it will be set to "Back"
+
+@end
+
+@interface UIViewController (BackButtonItemTitle) <BackButtonItemTitleProtocol>
+
+@end

--- a/Categories/UIKit/UIViewController/UIViewController+BackButtonItemTitle.m
+++ b/Categories/UIKit/UIViewController/UIViewController+BackButtonItemTitle.m
@@ -29,7 +29,7 @@
     }
     
     if (!backButtonTitle) {
-        backButtonTitle = @" ";
+        backButtonTitle = viewController.title;
     }
     
     UIBarButtonItem *backButtonItem = [[UIBarButtonItem alloc] initWithTitle:backButtonTitle

--- a/Categories/UIKit/UIViewController/UIViewController+BackButtonItemTitle.m
+++ b/Categories/UIKit/UIViewController/UIViewController+BackButtonItemTitle.m
@@ -1,0 +1,43 @@
+//
+//  UIViewController+BackButtonItemTitle.m
+//  Author ： https://github.com/KevinHM
+//
+//  Created by KevinHM on 15/8/6.
+//  Copyright (c) 2015年 KevinHM. All rights reserved.
+//
+
+#import "UIViewController+BackButtonItemTitle.h"
+
+@implementation UIViewController (BackButtonItemTitle)
+
+@end
+
+@implementation UINavigationController (NavigationItemBackBtnTile)
+
+- (BOOL)navigationBar:(UINavigationBar *)navigationBar shouldPushItem:(UINavigationItem *)item {
+    
+    UIViewController * viewController = self.viewControllers.count > 1 ? \
+                    [self.viewControllers objectAtIndex:self.viewControllers.count - 2] : nil;
+    
+    if (!viewController) {
+        return YES;
+    }
+    
+    NSString *backButtonTitle = nil;
+    if ([viewController respondsToSelector:@selector(navigationItemBackBarButtonTitle)]) {
+        backButtonTitle = [viewController navigationItemBackBarButtonTitle];
+    }
+    
+    if (!backButtonTitle) {
+        backButtonTitle = @" ";
+    }
+    
+    UIBarButtonItem *backButtonItem = [[UIBarButtonItem alloc] initWithTitle:backButtonTitle
+                                                                       style:UIBarButtonItemStylePlain
+                                                                      target:nil action:nil];
+    viewController.navigationItem.backBarButtonItem = backButtonItem;
+    
+    return YES;
+}
+
+@end

--- a/IOS-Categories.xcodeproj/project.pbxproj
+++ b/IOS-Categories.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		7926E6931B736E8200888EB9 /* UIViewController+BackButtonItemTitle.m in Sources */ = {isa = PBXBuildFile; fileRef = 7926E6921B736E8200888EB9 /* UIViewController+BackButtonItemTitle.m */; };
 		798256171B3A57340033A0C1 /* UIViewController+BackButtonHandler.m in Sources */ = {isa = PBXBuildFile; fileRef = 798256161B3A57340033A0C1 /* UIViewController+BackButtonHandler.m */; };
 		7982561A1B3A59060033A0C1 /* NSString+RegexCategory.m in Sources */ = {isa = PBXBuildFile; fileRef = 798256191B3A59060033A0C1 /* NSString+RegexCategory.m */; };
 		A202D9621B0F6C4400EAB199 /* NSDate+Reporting.m in Sources */ = {isa = PBXBuildFile; fileRef = A202D9611B0F6C4400EAB199 /* NSDate+Reporting.m */; };
@@ -338,6 +339,8 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
+		7926E6911B736E8200888EB9 /* UIViewController+BackButtonItemTitle.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "UIViewController+BackButtonItemTitle.h"; sourceTree = "<group>"; };
+		7926E6921B736E8200888EB9 /* UIViewController+BackButtonItemTitle.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "UIViewController+BackButtonItemTitle.m"; sourceTree = "<group>"; };
 		798256151B3A57340033A0C1 /* UIViewController+BackButtonHandler.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "UIViewController+BackButtonHandler.h"; sourceTree = "<group>"; };
 		798256161B3A57340033A0C1 /* UIViewController+BackButtonHandler.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "UIViewController+BackButtonHandler.m"; sourceTree = "<group>"; };
 		798256181B3A59060033A0C1 /* NSString+RegexCategory.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "NSString+RegexCategory.h"; sourceTree = "<group>"; };
@@ -2200,6 +2203,8 @@
 		A28BE31F1A3E9FDC005C4AC6 /* UIViewController */ = {
 			isa = PBXGroup;
 			children = (
+				7926E6911B736E8200888EB9 /* UIViewController+BackButtonItemTitle.h */,
+				7926E6921B736E8200888EB9 /* UIViewController+BackButtonItemTitle.m */,
 				A2B995D11B46797500011613 /* UIViewController+BlockSegue.h */,
 				A2B995D21B46797500011613 /* UIViewController+BlockSegue.m */,
 				A23C10841B3D39AD00FA34AA /* UIViewController+BackButtonTouched.h */,
@@ -2960,6 +2965,7 @@
 				A202D9A71B102D7800EAB199 /* NSNumberDemoViewController.m in Sources */,
 				A292BDCD1B03422D002DAB71 /* NSString+RemoveEmoji.m in Sources */,
 				A202D99A1B0F916900EAB199 /* UIControlDemoViewController.m in Sources */,
+				7926E6931B736E8200888EB9 /* UIViewController+BackButtonItemTitle.m in Sources */,
 				A2FD5B4B1A52687000555EA2 /* NSException+Trace.m in Sources */,
 				A2958CBD1B357C5C00D7AA0F /* UIScrollView+Direction.m in Sources */,
 				A27E931E1B381D930010C7EA /* UIFont+DynamicFontControl.m in Sources */,


### PR DESCRIPTION
使用：
在当前ViewController中导入该category,实现方法`navigationItemBackBarButtonTitle`,即可自定义原生的导航Push后返回键的title！